### PR TITLE
Implemented Go routines for health checks

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,10 +16,9 @@ upstreams:
     servers:
       - "http://localhost:8083"
       - "http://localhost:8084"
-      - "http://localhost:8085"
     healthCheck:
       url: "/health"
-      interval: 5s
+      interval: 2s
       timeout: 1s
     rateLimit:
       limit: 100

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,13 @@ type Config struct {
 	Upstreams []Upstream `yaml:"upstreams"`
 }
 
+type Upstream struct {
+	Name        string      `yaml:"name"`
+	Servers     []string    `yaml:"servers"`
+	HealthCheck HealthCheck `yaml:"healthCheck"`
+	RateLimit   RateLimit   `yaml:"rateLimit"`
+}
+
 type HealthCheck struct {
 	Url      string        `yaml:"url"`
 	Interval time.Duration `yaml:"interval"`
@@ -17,11 +24,4 @@ type HealthCheck struct {
 type RateLimit struct {
 	Limit    int           `yaml:"limit"`
 	Interval time.Duration `yaml:"interval"`
-}
-
-type Upstream struct {
-	Name        string      `yaml:"name"`
-	Servers     []string    `yaml:"servers"`
-	HealthCheck HealthCheck `yaml:"healthCheck"`
-	RateLimit   RateLimit   `yaml:"rateLimit"`
 }

--- a/internal/healthchecks/healthCheck.go
+++ b/internal/healthchecks/healthCheck.go
@@ -9,6 +9,11 @@ import (
 	"github.com/janithht/GoStreamBalancer/internal/config"
 )
 
+type HealthCheckTask struct {
+	Server            string
+	HealthCheckConfig config.HealthCheck
+}
+
 func checkServerHealth(server string, healthCheckConfig config.HealthCheck) bool {
 	client := http.Client{
 		Timeout: healthCheckConfig.Timeout,
@@ -16,25 +21,36 @@ func checkServerHealth(server string, healthCheckConfig config.HealthCheck) bool
 	res, err := client.Get(server + healthCheckConfig.Url)
 	return err == nil && res.StatusCode == 200
 }
-func performHealthCheckForUpstream(upstream config.Upstream) {
-	for {
-		fmt.Println()
-		for i := len(upstream.Servers) - 1; i >= 0; i-- {
-			server := upstream.Servers[i]
-			if !checkServerHealth(server, upstream.HealthCheck) {
-				log.Printf("Server %s failed health check, removing from pool\n", server)
-			} else {
-				log.Printf("Server %s passed health check\n", server)
-			}
+
+func worker(id int, tasks <-chan HealthCheckTask) {
+	for task := range tasks {
+		if !checkServerHealth(task.Server, task.HealthCheckConfig) {
+			log.Printf("[Worker %d] Server %s failed health check, removing from pool\n", id, task.Server)
+		} else {
+			log.Printf("[Worker %d] Server %s passed health check\n", id, task.Server)
 		}
-		time.Sleep(upstream.HealthCheck.Interval)
 	}
 }
 
-func PerformHealthChecks(config *config.Config) {
-	for _, upstream := range config.Upstreams {
-		go performHealthCheckForUpstream(upstream)
+func PerformHealthChecks(cfg *config.Config) {
+	const numWorkers = 10
+	tasks := make(chan HealthCheckTask, 100)
+
+	for i := 0; i < numWorkers; i++ {
+		go worker(i, tasks)
 	}
 
-	select {}
+	for {
+		fmt.Println()
+		for _, upstream := range cfg.Upstreams {
+			for _, server := range upstream.Servers {
+				task := HealthCheckTask{
+					Server:            server,
+					HealthCheckConfig: upstream.HealthCheck,
+				}
+				tasks <- task
+			}
+			time.Sleep(upstream.HealthCheck.Interval)
+		}
+	}
 }

--- a/internal/healthchecks/healthCheck.go
+++ b/internal/healthchecks/healthCheck.go
@@ -16,20 +16,24 @@ func checkServerHealth(server string, healthCheckConfig config.HealthCheck) bool
 	res, err := client.Get(server + healthCheckConfig.Url)
 	return err == nil && res.StatusCode == 200
 }
-
-func PerformHealthChecks(config *config.Config) {
+func performHealthCheckForUpstream(upstream config.Upstream) {
 	for {
 		fmt.Println()
-		for _, upstream := range config.Upstreams {
-			for i := len(upstream.Servers) - 1; i >= 0; i-- {
-				server := upstream.Servers[i]
-				if !checkServerHealth(server, upstream.HealthCheck) {
-					log.Printf("Server %s failed health check, removing from pool\n", server)
-					// Remove server from slice safely.
-					upstream.Servers = append(upstream.Servers[:i], upstream.Servers[i+1:]...)
-				}
+		for i := len(upstream.Servers) - 1; i >= 0; i-- {
+			server := upstream.Servers[i]
+			if !checkServerHealth(server, upstream.HealthCheck) {
+				log.Printf("Server %s failed health check, removing from pool\n", server)
+				// Properly synchronize server removal here.
 			}
 		}
-		time.Sleep(config.Upstreams[0].HealthCheck.Interval)
+		time.Sleep(upstream.HealthCheck.Interval)
 	}
+}
+
+func PerformHealthChecks(config *config.Config) {
+	for _, upstream := range config.Upstreams {
+		go performHealthCheckForUpstream(upstream)
+	}
+
+	select {}
 }

--- a/internal/healthchecks/healthCheck.go
+++ b/internal/healthchecks/healthCheck.go
@@ -23,6 +23,8 @@ func performHealthCheckForUpstream(upstream config.Upstream) {
 			server := upstream.Servers[i]
 			if !checkServerHealth(server, upstream.HealthCheck) {
 				log.Printf("Server %s failed health check, removing from pool\n", server)
+			} else {
+				log.Printf("Server %s passed health check\n", server)
 			}
 		}
 		time.Sleep(upstream.HealthCheck.Interval)

--- a/internal/healthchecks/healthCheck.go
+++ b/internal/healthchecks/healthCheck.go
@@ -23,7 +23,6 @@ func performHealthCheckForUpstream(upstream config.Upstream) {
 			server := upstream.Servers[i]
 			if !checkServerHealth(server, upstream.HealthCheck) {
 				log.Printf("Server %s failed health check, removing from pool\n", server)
-				// Properly synchronize server removal here.
 			}
 		}
 		time.Sleep(upstream.HealthCheck.Interval)

--- a/internal/healthchecks/types.go
+++ b/internal/healthchecks/types.go
@@ -1,0 +1,14 @@
+package healthchecks
+
+import "time"
+
+type HealthCheck struct {
+	Url      string        `yaml:"url"`
+	Interval time.Duration `yaml:"interval"`
+	Timeout  time.Duration `yaml:"timeout"`
+}
+
+type RateLimit struct {
+	Limit    int           `yaml:"limit"`
+	Interval time.Duration `yaml:"interval"`
+}

--- a/internal/server/start_server.go
+++ b/internal/server/start_server.go
@@ -15,7 +15,7 @@ var currentServerIndex int = 0
 
 func StartServer(upstreams []config.Upstream) {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		upstreamName := r.Header.Get("X-Upstream-Name")
+		upstreamName := r.Header.Get("Host")
 
 		var selectedUpstream *config.Upstream
 		for _, upstream := range upstreams {

--- a/main.go
+++ b/main.go
@@ -1,7 +1,12 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/janithht/GoStreamBalancer/internal/config"
 
@@ -14,12 +19,24 @@ func main() {
 
 	cfg, err := config.Readconfig("config.yaml")
 
+	ctx, cancel := context.WithCancel(context.Background())
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	defer cancel()
+
+	go func() {
+		<-sigs
+		cancel()
+		fmt.Println("Shutting down health checks...")
+	}()
+
 	if err != nil {
 		log.Fatalf("Error reading config: %v", err)
 		return
 	}
 	log.Printf("Config parsed successfully: %v\n", cfg)
 
-	go healthchecks.PerformHealthChecks(cfg)
+	go healthchecks.PerformHealthChecks(ctx, cfg)
 	server.StartServer(cfg.Upstreams)
 }


### PR DESCRIPTION
This pull request implements parallel go routines to run health checks for each upstream.
#Issues:
- Handling Different Numbers of Servers in Each Upstream
- Respecting Unique Health Check Intervals
